### PR TITLE
Issue #17: Add privacy:metadata language string

### DIFF
--- a/lang/en/customfield_semester.php
+++ b/lang/en/customfield_semester.php
@@ -49,3 +49,4 @@ $string['visibleincoursesettings_desc'] = 'The semester field is visible and edi
 $string['wintersemester'] = 'WT {$a}';
 $string['wintertermstartmonth'] = 'The month when winter term starts';
 $string['wintertermstartmonth_desc'] = 'With this setting, you define in which month the winter term starts.';
+$string['privacy:metadata'] = 'The Semester menu field type plugin doesn\'t store any personal data; it uses tables defined in core.';


### PR DESCRIPTION
**Description:** Add `privacy:metadata` language string to resolve core unit test failure. See Issue #17 for more details. After adding the language string, unit test passes:

```
vendor/bin/phpunit --filter test_get_registry_metadata_count admin/tool/dataprivacy/tests/metadata_registry_test.php
Moodle 4.5.11+ (Build: 20260501), 11cb1f29138b7bf3a451cad5cc1edc4b1ef85693
Php: 8.3.27, pgsql: 17.8 (Debian 17.8-1.pgdg13+1), OS: Linux 6.17.0-23-generic x86_64
PHPUnit 9.6.34 by Sebastian Bergmann and contributors.

.                                                                   1 / 1 (100%)

Time: 00:00.465, Memory: 97.00 MB
```